### PR TITLE
Improved config loading allowing more options.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ node_modules/
 
 # Build directory
 out/
+
+# Configs
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -29,12 +29,21 @@ See the [extension installation guide](https://code.visualstudio.com/docs/editor
 
 ## Supported settings
 
-**useStylelintConfigOverrides**
+**configBasedir**
 
-  * Type: `boolean`
-  * Default: `false`
+  * Type: `string`
+  * Default: `null`
 
-Overrides rules using Stylelint plugin settings.
+Base working directory; useful for stylelint `extends` parameter.
+
+**config**
+
+  * Type: `object || string`
+  * Default: `null`
+
+Config object for stylelint or path to a stylelint config file.
+
+*Will automatically look for `.stylelintrc` and `stylelint.config.js` in workspace root, or a `stylelint` param in the `package.json`, if config is omitted.*
 
 ## Keyboard shortcuts
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
           ],
           "default": "",
           "description": "Config object for stylelint or path to a stylelint config file."
+        },
+        "stylefmt.useStylelintConfigOverrides": {
+          "type": "boolean",
+          "default": false,
+          "description": "Overrides rules using stylelint plugin setting 'stylelint.configOverrides'."
         }
       }
     },
@@ -67,14 +72,15 @@
     "@types/node": "^7.0.12",
     "tslint": "^5.1.0",
     "tslint-config-xo": "^1.2.0",
-    "typescript": "^2.2.2",
-    "vscode": "^1.1.0",
-    "vscode-config-resolver": "^1.0.3"
+    "typescript": "^2.2.2"
   },
   "dependencies": {
+    "extend": "3.0.0",
     "postcss": "5.2.17",
     "postcss-scss": "0.4.1",
-    "stylefmt": "5.3.2"
+    "stylefmt": "5.3.2",
+    "vscode": "1.1.0",
+    "vscode-config-resolver": "1.0.3"
   },
   "scripts": {
     "postinstall": "node ./node_modules/vscode/bin/install",

--- a/package.json
+++ b/package.json
@@ -41,10 +41,18 @@
       "type": "object",
       "title": "stylefmt configuration",
       "properties": {
-        "stylefmt.useStylelintConfigOverrides": {
-          "type": "boolean",
-          "default": false,
-          "description": "Overrides rules using Stylelint plugin settings."
+        "stylefmt.configBasedir": {
+          "type": "string",
+          "default": "",
+          "description": "Base working directory; useful for stylelint extends parameter."
+        },
+        "stylefmt.config": {
+          "type": [
+            "string",
+            "object"
+          ],
+          "default": "",
+          "description": "Config object for stylelint or path to a stylelint config file."
         }
       }
     },
@@ -60,7 +68,8 @@
     "tslint": "^5.1.0",
     "tslint-config-xo": "^1.2.0",
     "typescript": "^2.2.2",
-    "vscode": "^1.1.0"
+    "vscode": "^1.1.0",
+    "vscode-config-resolver": "^1.0.3"
   },
   "dependencies": {
     "postcss": "5.2.17",


### PR DESCRIPTION
+ Added configBasedir and config options.
+ Configs can now be loaded from a specified file path or from ".stylelintrc" and "stylelint.config.js".
+ Config can also be specified as objects either in vscode settings or in the package.json.
- Removed useStylelintConfigOverrides because it became obsolete.