### PR TITLE
Update stylefmt

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,10 @@
           "description": "Base working directory; useful for stylelint extends parameter."
         },
         "stylefmt.config": {
-          "type": ["string", "object"],
+          "type": [
+            "string",
+            "object"
+          ],
           "default": "",
           "description": "Config object for stylelint or path to a stylelint config file."
         },
@@ -88,7 +91,7 @@
     "extend": "3.0.1",
     "postcss": "6.0.8",
     "postcss-scss": "1.0.2",
-    "stylefmt": "6.0.0",
+    "stylefmt": "6.0.3",
     "vscode": "1.1.5"
   },
   "scripts": {


### PR DESCRIPTION
### What is the purpose of this pull request?

Older versions of stylefmt and stylelint cause problems with newer standards. By updating stylefmt dependency to 6.0.3 and stylelint to 13.2.1 this extension seems to work fine. This is directly related to [this issue in particular](https://github.com/morishitter/stylefmt/issues/334#issuecomment-436552167) but can be fixed inside the extension.

I never moved to prettier because despite it being good for javascript and json, it sucks for SCSS, map-gets and mixins. Stylefmt does everything properly.

This PR fixes issues #158, #156, #138, #116 and #96.

### What changes did you make? (Give an overview)

Updated stylefmt and stylelint.
...
